### PR TITLE
feat: support climate entities as temperature sensors

### DIFF
--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -298,12 +298,18 @@ class SmartHeatingController:
             return None
 
     def _get_state_float(self, entity_id: str | None) -> float | None:
-        """Numerischen Zustand einer Entity lesen."""
+        """Numerischen Zustand einer Entity lesen.
+
+        Für climate.*-Entities wird current_temperature aus den Attributen
+        gelesen, da state dort den HVAC-Modus enthält (z.B. 'heat_cool').
+        """
         if not entity_id:
             return None
         state = self.hass.states.get(entity_id)
         if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return None
+        if entity_id.startswith("climate."):
+            return self._safe_float(state.attributes.get("current_temperature"))
         return self._safe_float(state.state)
 
     def _room_temp(self, room: dict[str, Any]) -> float | None:

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "2.9.1"
+  "version": "2.9.2"
 }

--- a/custom_components/smartdome_heat_control/www/app.js
+++ b/custom_components/smartdome_heat_control/www/app.js
@@ -518,6 +518,12 @@ function sortByEntityId(items) {
 }
 
 function isTemperatureSensor(entity) {
+  // climate entities with current_temperature attribute can be used as sensors
+  if (entity?.entity_id?.startsWith("climate.")) {
+    const currentTemp = entity.attributes?.current_temperature;
+    return currentTemp !== undefined && currentTemp !== null && !Number.isNaN(Number(currentTemp));
+  }
+
   if (!entity?.entity_id?.startsWith("sensor.")) {
     return false;
   }
@@ -710,7 +716,12 @@ function getSensorTemperature(sensorId) {
     return null;
   }
 
-  const value = Number(sensor.state);
+  // climate entities expose temperature in attributes, not state
+  const raw = sensor.entity_id?.startsWith("climate.")
+    ? sensor.attributes?.current_temperature
+    : sensor.state;
+
+  const value = Number(raw);
   if (!Number.isFinite(value)) {
     return null;
   }
@@ -965,7 +976,7 @@ function getEntityIcon(entityId) {
     return "—";
   }
   if (entityId.startsWith("climate.")) {
-    return "🔥";
+    return "🌡️";
   }
   if (entityId.startsWith("binary_sensor.")) {
     return "🪟";


### PR DESCRIPTION
climate.* entities expose their measured temperature via the current_temperature attribute, not via state (which holds the HVAC mode).

- controller.py: _get_state_float now reads current_temperature from attributes when the entity_id starts with climate.
- app.js: isTemperatureSensor now returns true for climate entities that have a numeric current_temperature attribute, so they appear in all sensor pickers (main sensor, room sensor, circuit sensor)
- app.js: getSensorTemperature reads current_temperature attribute for climate entities so live temperature display works correctly
- app.js: getEntityIcon uses 🌡️ for climate entities used as sensors
- bump version to 2.9.2

https://claude.ai/code/session_01FZiHYeZcCDjz3kxAD7PyKT