### PR TITLE
fix: Hauptthermostat bleibt bei 24,5 °C trotz idle Räumen (Energy-Mode)

### DIFF
--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -662,11 +662,24 @@ class SmartHeatingController:
         desired = self._round_to_step(float(temp), step)
         previous = self._desired_targets.get(entity_id)
 
-        if previous is not None and abs(previous - desired) < 0.01:
-            return
-
         now_ts = dt_util.now().timestamp()
         last_sent = self._last_command_sent_at.get(entity_id, 0.0)
+
+        if previous is not None and abs(previous - desired) < 0.01:
+            # Desired hasn't changed — but check whether the thermostat entity
+            # was reset externally (e.g. CCU weekly programme, manual override).
+            # Only re-sync after a cooldown so we don't fight a just-sent command.
+            if (now_ts - last_sent) < 90.0:
+                return
+            entity_state = self.hass.states.get(entity_id)
+            if entity_state:
+                entity_setpoint = self._safe_float(
+                    entity_state.attributes.get("temperature")
+                )
+                if entity_setpoint is None or abs(entity_setpoint - desired) < 0.5:
+                    return  # entity matches desired — nothing to do
+            else:
+                return  # entity unavailable — skip
 
         if min_interval > 0 and (now_ts - last_sent) < min_interval:
             return
@@ -881,7 +894,7 @@ class SmartHeatingController:
             self._residual_heat_hold_until.pop(room_id, None)
             return ROOM_STATE_IDLE
 
-        if current_state in (ROOM_STATE_IDLE, ROOM_STATE_RESIDUAL_HOLD):
+        if current_state == ROOM_STATE_IDLE:
             if actual < (target - tolerance):
                 self._room_state[room_id] = ROOM_STATE_HEATING
                 self._residual_heat_hold_until.pop(room_id, None)

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.0.6"
+  "version": "3.0.7"
 }


### PR DESCRIPTION
Zwei unabhängige Ursachen wurden behoben:

**Bug A – RESIDUAL_HOLD → HEATING Oszillation (Energy-Mode)** Im Energy-Mode konnte ein Raum aus dem RESIDUAL_HOLD-Zustand direkt wieder in HEATING springen, sobald der Sensor minimal unter target − tolerance fiel (z. B. durch Sensorrauschen). Das ließ das Hauptthermostat ständig zwischen 24,5 °C (Heizen) und min_temp (Hold) pendeln.
Fix: Neu-Heizen ist nur noch aus dem IDLE-Zustand möglich. RESIDUAL_HOLD läuft immer vollständig ab, bevor ein neuer Heizzyklus starten kann.

**Bug B – CCU-Wochenprogramm überschreibt SmartDome-Sollwert** `_set_temp_if_needed` unterdrückte Re-Sends, wenn sich der gewünschte Wert gegenüber dem letzten gesendeten nicht geändert hatte. Setzt die CCU den Thermostat über ihr eigenes Wochenprogramm zurück (z. B. auf 24,5 °C), erkannte SmartDome das nicht und ließ den Wert stehen.
Fix: Weicht der tatsächliche Entity-Sollwert nach ≥ 90 Sekunden Abkühlzeit um ≥ 0,5 °C vom gewünschten Wert ab, wird der Befehl erneut gesendet (Re-Sync).

https://claude.ai/code/session_01FZiHYeZcCDjz3kxAD7PyKT