### PR TITLE
fix: Hauptthermostat schaltet nach Heizende garantiert auf min_temp

### DIFF
--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -123,6 +123,11 @@ class SmartHeatingController:
         # Zuletzt wirklich angewendeter effektiver Zustand pro Raum
         self._last_applied_room_state: dict[str, str] = {}
 
+        # Ob der Heizkreis-Hauptthermostat im letzten Zyklus aktiv war
+        # (True = mind. ein Raum heizte). Wird genutzt um beim Übergang
+        # heating→idle einen garantierten min_temp-Befehl zu senden.
+        self._circuit_heating_active: dict[str, bool] = {}
+
         self._apply_config_defaults()
 
     async def async_start(self) -> None:
@@ -818,6 +823,7 @@ class SmartHeatingController:
         self._residual_heat_hold_until.clear()
         self._last_command_sent_at.clear()
         self._last_applied_room_state.clear()
+        self._circuit_heating_active.clear()
 
     def _restore_non_boost_targets(self) -> None:
         """Thermostate beim Deaktivieren auf normale Zielwerte zurücksetzen."""
@@ -1090,6 +1096,13 @@ class SmartHeatingController:
                     rs["state"] == ROOM_STATE_HEATING
                     for rs in circuit_room_states.values()
                 )
+                # Übergang heating → idle: _desired_targets löschen damit
+                # min_temp-Befehl garantiert gesendet wird.
+                was_heating = self._circuit_heating_active.get(circuit_id, False)
+                if was_heating and not any_circuit_needs_heat:
+                    self._desired_targets.pop(ct, None)
+                self._circuit_heating_active[circuit_id] = any_circuit_needs_heat
+
                 if any_circuit_needs_heat:
                     # Dynamic boost: setpoint = current sensor + boost_delta so the
                     # heating circuit turns ON reliably regardless of room targets.
@@ -1123,6 +1136,15 @@ class SmartHeatingController:
             )
             main_thermostat = self._as_entity_id(self.config.get(CONF_MAIN_THERMOSTAT))
             if main_thermostat and main_thermostat not in room_managed_thermostats:
+                # Übergang heating → idle: _desired_targets löschen damit
+                # min_temp-Befehl garantiert gesendet wird.
+                was_heating = self._circuit_heating_active.get(
+                    main_thermostat, False
+                )
+                if was_heating and not any_room_needs_heat:
+                    self._desired_targets.pop(main_thermostat, None)
+                self._circuit_heating_active[main_thermostat] = any_room_needs_heat
+
                 if any_room_needs_heat:
                     # Dynamic boost: setpoint = current sensor + boost_delta so the
                     # heating circuit turns ON reliably regardless of room targets.

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.0.8"
+  "version": "3.0.9"
 }


### PR DESCRIPTION
Ursache: Beim Übergang any_room_needs_heat True→False konnte _desired_targets für den Hauptthermostat einen Wert enthalten, der identisch oder zu ähnlich dem neuen min_temp-Ziel war (je nach sensor-basiertem Boost-Wert und CCU-Abkühlzeit). In diesem Fall unterdrückte die Deduplizierungs-Logik in _set_temp_if_needed den Schreibbefehl.

Fix: Neues Dict _circuit_heating_active speichert pro Hauptthermostat, ob im letzten Zyklus mindestens ein Raum geheizt hat. Beim Übergang heating→idle wird _desired_targets[main_thermostat] gezielt gelöscht, sodass _set_temp_if_needed den min_temp-Befehl unbedingt sendet – unabhängig vom vorherigen Wert.

Gilt sowohl für Einzel- als auch Mehrkreis-Setups.

https://claude.ai/code/session_01FZiHYeZcCDjz3kxAD7PyKT