### PR TITLE
fix: CCU-Re-Sync-Loop entfernt – _set_temp_if_needed wieder einfach

### DIFF
--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -667,24 +667,11 @@ class SmartHeatingController:
         desired = self._round_to_step(float(temp), step)
         previous = self._desired_targets.get(entity_id)
 
+        if previous is not None and abs(previous - desired) < 0.01:
+            return
+
         now_ts = dt_util.now().timestamp()
         last_sent = self._last_command_sent_at.get(entity_id, 0.0)
-
-        if previous is not None and abs(previous - desired) < 0.01:
-            # Desired hasn't changed — but check whether the thermostat entity
-            # was reset externally (e.g. CCU weekly programme, manual override).
-            # Only re-sync after a cooldown so we don't fight a just-sent command.
-            if (now_ts - last_sent) < 90.0:
-                return
-            entity_state = self.hass.states.get(entity_id)
-            if entity_state:
-                entity_setpoint = self._safe_float(
-                    entity_state.attributes.get("temperature")
-                )
-                if entity_setpoint is None or abs(entity_setpoint - desired) < 0.5:
-                    return  # entity matches desired — nothing to do
-            else:
-                return  # entity unavailable — skip
 
         if min_interval > 0 and (now_ts - last_sent) < min_interval:
             return

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.0.9"
+  "version": "3.0.10"
 }


### PR DESCRIPTION
Fix B (3.0.7) prüfte alle 90 Sekunden ob der tatsächliche Entity-Wert vom gewünschten Sollwert abweicht und sendete dann erneut. Wenn die CCU ein eigenes Wochenprogramm für den Hauptthermostat hat, führte das zu einem Dauerkonflikt: SmartDome sendet min_temp → CCU setzt auf ihr Programm zurück → SmartDome sendet nach 90 s wieder → sichtbare Oszillation im Minutentakt (Graph: Sollwert wechselt ständig zwischen 4 °C und 24 °C).

Fix: CCU-Re-Sync-Logik aus _set_temp_if_needed entfernt. _set_temp_if_needed sendet nur noch dann, wenn sich der von SmartDome gewünschte Sollwert tatsächlich geändert hat (ursprüngliche Logik).

Der garantierte min_temp-Befehl beim Übergang heating→idle bleibt erhalten (3.0.9: _circuit_heating_active + _desired_targets.pop). Das stellt sicher, dass SmartDome den Hauptthermostat bei jedem echten Zustandswechsel korrekt schaltet – ohne gegen ein CCU-Programm zu kämpfen.

Hinweis: Wer möchte, dass der Hauptthermostat dauerhaft von SmartDome gehalten wird, sollte das CCU-Wochenprogramm für diesen Thermostat deaktivieren.

https://claude.ai/code/session_01FZiHYeZcCDjz3kxAD7PyKT