### PR TITLE
fix: Heizpumpensteuerung ist kein Pflichtfeld mehr (V3.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.2.8] – 2026-03-27
+
+### 🔧 Fix: Heizpumpensteuerung ist kein Pflichtfeld mehr
+
+**Problem:** Beim Einrichten der Integration erschien die Fehlermeldung „Nicht alle Pflichtfelder ausgefüllt", obwohl laut Dokumentation das Feld „Heizpumpensteuerung" leer gelassen werden kann. Die Konfiguration ließ sich dadurch nicht abschließen.
+
+**Ursache:** `CONF_MAIN_THERMOSTAT` war in `config_flow.py` als `vol.Required` deklariert – sowohl im initialen Setup-Schritt als auch in den globalen Einstellungen. Das machte das Feld auf Voluptuous-Ebene zum Pflichtfeld, obwohl der Controller intern bereits `None` korrekt behandelt.
+
+**Fix:** Beide Vorkommen auf `vol.Optional` geändert. Das Feld kann jetzt leer gelassen werden; die Integration funktioniert dann ohne zentrale Heizpumpensteuerung (z. B. bei reiner Raumthermostat-Steuerung).
+
+---
+
+**EN:** Fixed a validation error that prevented completing the setup when "Heizpumpensteuerung" was left empty. The field was declared as `vol.Required` in both the initial config step and the global settings step, making it mandatory at the form level even though the controller already handled `None` correctly. Changed both occurrences to `vol.Optional`.
+
+---
+
 ## [3.2.7] – 2026-03-22
 
 ### 🔧 Fix: Konfiguration springt nach „Konfiguration übernehmen" zurück

--- a/custom_components/smartdome_heat_control/config_flow.py
+++ b/custom_components/smartdome_heat_control/config_flow.py
@@ -121,7 +121,7 @@ class SmartdomeHeatControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_MAIN_THERMOSTAT): _climate_selector(),
+                vol.Optional(CONF_MAIN_THERMOSTAT): _climate_selector(),
                 vol.Optional(CONF_MAIN_SENSOR): _temperature_sensor_selector(),
                 vol.Optional(
                     CONF_BOOST_DELTA,
@@ -285,7 +285,7 @@ class SmartdomeOptionsFlow(config_entries.OptionsFlow):
 
         schema = vol.Schema(
             {
-                vol.Required(
+                vol.Optional(
                     CONF_MAIN_THERMOSTAT,
                     default=data.get(CONF_MAIN_THERMOSTAT),
                 ): _climate_selector(),

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.2.6"
+  "version": "3.2.8"
 }


### PR DESCRIPTION
## Summary

- `CONF_MAIN_THERMOSTAT` war als `vol.Required` deklariert, obwohl das Feld laut Dokumentation optional ist
- Nutzer konnten die Integration nicht einrichten, wenn sie keine Heizpumpensteuerung angeben wollten
- Beide Vorkommen in `config_flow.py` (initiales Setup + globale Einstellungen) auf `vol.Optional` geändert

## Test plan

- [ ] Integration ohne Heizpumpensteuerung einrichten → kein Validierungsfehler mehr
- [ ] Integration mit Heizpumpensteuerung einrichten → funktioniert weiterhin
- [ ] Globale Einstellungen ohne Heizpumpensteuerung speichern → kein Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)