### PR TITLE
feat: Globale Temperaturen, Raum-Reihenfolge & Heizmodus pro Raum (V3.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [3.3.0] – 2026-04-02
+
+### ✨ Feature: Globale Temperatureinstellungen (#54)
+
+Neuer Abschnitt **"Temperaturen"** in der globalen Seitenleiste mit drei Feldern:
+- **Zieltemperatur Tag** – globaler Standardwert für den Tagbetrieb
+- **Zieltemperatur Nacht** – globaler Standardwert für die Nachtabsenkung
+- **Away-Temperatur** – globaler Standardwert für den Abwesenheitsmodus
+
+Ein neuer Button **"Globale Temperaturen in alle Räume übernehmen"** setzt alle Raumwerte auf die globalen Werte. Neue Räume übernehmen beim Anlegen automatisch die globalen Werte.
+
+---
+
+### ✨ Feature: Reihenfolge der Räume (#53)
+
+Räume können nun per **Drag & Drop** (≡ Handle) neu angeordnet werden. Die Reihenfolge wird beim Speichern persistiert.
+
+Zusätzlich ist jede Raumkarte über den **▼/▶ Button** oben rechts ein- und ausklappbar, um die Übersicht bei vielen Räumen zu verbessern.
+
+---
+
+### ✨ Feature: Heizmodus pro Raum (#56)
+
+Jede Raumkarte hat nun einen **Heizmodus-Selector** direkt unter dem Raumtitel:
+- **Global** (Standard) – übernimmt den globalen Heizmodus
+- **Comfort / Balanced / Energy / Adaptive** – raumspezifische Überschreibung
+
+Die Heizlogik im Controller verwendet den Raum-Modus wenn gesetzt, sonst den globalen Modus.
+
+---
+
+**EN:** Three new features: global temperature defaults with "apply to all rooms" button (#54); room drag-and-drop reordering + collapsible room cards (#53); per-room heating mode override with "Global" fallback (#56).
+
+---
+
 ## [3.2.8] – 2026-03-27
 
 ### 🔧 Fix: Heizpumpensteuerung ist kein Pflichtfeld mehr

--- a/custom_components/smartdome_heat_control/__init__.py
+++ b/custom_components/smartdome_heat_control/__init__.py
@@ -32,6 +32,8 @@ from .const import (
     CONF_ROOMS,
     CONF_ROOM_CIRCUIT_ID,
     CONF_ROOM_CONTROL_PROFILE,
+    CONF_ROOM_HEATING_MODE,
+    CONF_ROOM_ORDER,
     CONF_ROOM_THERMOSTAT_OFFSET,
     CONF_ROOM_WINDOW_SENSORS,
     DEFAULT_ROOM_CONTROL_PROFILE,
@@ -50,7 +52,13 @@ from .const import (
     CONF_VACATION_ENABLED,
     CONF_VACATION_TEMPERATURE,
     CONF_ENERGY_RESIDUAL_HEAT_HOLD,
+    CONF_GLOBAL_TARGET_DAY,
+    CONF_GLOBAL_TARGET_NIGHT,
+    CONF_GLOBAL_AWAY_TEMPERATURE,
     DEFAULT_ENERGY_RESIDUAL_HEAT_HOLD,
+    DEFAULT_GLOBAL_TARGET_DAY,
+    DEFAULT_GLOBAL_TARGET_NIGHT,
+    DEFAULT_GLOBAL_AWAY_TEMPERATURE,
     DATA_CONTROLLER,
     DATA_ENABLED,
     DEFAULT_ADAPTIVE_OVERSHOOT,
@@ -299,6 +307,8 @@ def _normalize_rooms(rooms: Any) -> dict[str, dict[str, Any]]:
             CONF_ROOM_THERMOSTAT_OFFSET: float(
                 room.get(CONF_ROOM_THERMOSTAT_OFFSET, DEFAULT_ROOM_THERMOSTAT_OFFSET)
             ),
+            CONF_ROOM_ORDER: int(room.get(CONF_ROOM_ORDER, 0)),
+            CONF_ROOM_HEATING_MODE: room.get(CONF_ROOM_HEATING_MODE, ""),
         }
 
     return normalized
@@ -336,7 +346,10 @@ def _normalize_config(cfg: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault(CONF_HEATING_MODE, DEFAULT_HEATING_MODE)
     normalized[CONF_ROOMS] = _normalize_rooms(normalized.get(CONF_ROOMS, {}))
     normalized[CONF_CIRCUITS] = _normalize_circuits(normalized.get(CONF_CIRCUITS, {}))
-    normalized.setdefault(CONF_ENERGY_RESIDUAL_HEAT_HOLD,DEFAULT_ENERGY_RESIDUAL_HEAT_HOLD,)
+    normalized.setdefault(CONF_ENERGY_RESIDUAL_HEAT_HOLD, DEFAULT_ENERGY_RESIDUAL_HEAT_HOLD)
+    normalized.setdefault(CONF_GLOBAL_TARGET_DAY, DEFAULT_GLOBAL_TARGET_DAY)
+    normalized.setdefault(CONF_GLOBAL_TARGET_NIGHT, DEFAULT_GLOBAL_TARGET_NIGHT)
+    normalized.setdefault(CONF_GLOBAL_AWAY_TEMPERATURE, DEFAULT_GLOBAL_AWAY_TEMPERATURE)
     return normalized
 
 

--- a/custom_components/smartdome_heat_control/const.py
+++ b/custom_components/smartdome_heat_control/const.py
@@ -146,6 +146,20 @@ CONF_OUTDOOR_TEMP_CUTOFF = "outdoor_temp_cutoff"
 DEFAULT_OUTDOOR_TEMP_CUTOFF_ENABLED = False
 DEFAULT_OUTDOOR_TEMP_CUTOFF = 15.0
 
+# Feature #54 – Globale Temperatureinstellungen
+CONF_GLOBAL_TARGET_DAY = "global_target_day"
+CONF_GLOBAL_TARGET_NIGHT = "global_target_night"
+CONF_GLOBAL_AWAY_TEMPERATURE = "global_away_temperature"
+DEFAULT_GLOBAL_TARGET_DAY = 21.0
+DEFAULT_GLOBAL_TARGET_NIGHT = 18.0
+DEFAULT_GLOBAL_AWAY_TEMPERATURE = 17.0
+
+# Feature #53 – Reihenfolge der Räume
+CONF_ROOM_ORDER = "order"
+
+# Feature #56 – Heizmodus pro Raum
+CONF_ROOM_HEATING_MODE = "room_heating_mode"
+
 # Defaults
 DEFAULT_ENABLED = True
 DEFAULT_BOOST_DELTA = 2.0

--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_MAIN_SENSOR,
     CONF_MAIN_THERMOSTAT,
     CONF_ROOM_CIRCUIT_ID,
+    CONF_ROOM_HEATING_MODE,
     CONF_MORNING_BOOST_START,
     CONF_NIGHT_START,
     CONF_ROOMS,
@@ -736,8 +737,15 @@ class SmartHeatingController:
         )
 
     def _get_heating_mode(self) -> str:
-        """Aktuellen Heizmodus lesen."""
+        """Globalen Heizmodus lesen."""
         return str(self.config.get(CONF_HEATING_MODE, DEFAULT_HEATING_MODE))
+
+    def _get_room_heating_mode(self, room: dict[str, Any]) -> str:
+        """Heizmodus für einen Raum lesen (room-Override oder globaler Modus)."""
+        room_mode = str(room.get(CONF_ROOM_HEATING_MODE, "")).strip()
+        if room_mode in (HEATING_MODE_COMFORT, HEATING_MODE_BALANCED, HEATING_MODE_ENERGY, HEATING_MODE_ADAPTIVE):
+            return room_mode
+        return self._get_heating_mode()
 
     def _get_energy_residual_heat_hold_seconds(self) -> int:
         """Nachlaufzeit im Energy Mode."""
@@ -798,7 +806,7 @@ class SmartHeatingController:
         target_temp: float,
     ) -> float:
         """Fester Idle-Sollwert je nach Modus."""
-        mode = self._get_heating_mode()
+        mode = self._get_room_heating_mode(room)
         min_temp = self._thermostat_min_temp(thermostat_id)
         step = self._thermostat_target_step(thermostat_id)
 
@@ -899,6 +907,7 @@ class SmartHeatingController:
     def _update_room_state(
         self,
         room_id: str,
+        room: dict[str, Any],
         target: float,
         actual: float | None,
         pause_active: bool,
@@ -907,7 +916,7 @@ class SmartHeatingController:
     ) -> str:
         """Raumzustand bestimmen und nur bei echten Zustandswechseln ändern."""
         current_state = self._room_state.get(room_id, ROOM_STATE_IDLE)
-        mode = self._get_heating_mode()
+        mode = self._get_room_heating_mode(room)
         now_ts = dt_util.now().timestamp()
 
         if pause_active:
@@ -1072,7 +1081,6 @@ class SmartHeatingController:
 
         room_states: dict[str, dict[str, Any]] = {}
 
-        mode = self._get_heating_mode()
         outdoor_cutoff_active = self._is_outdoor_cutoff_active()
         if outdoor_cutoff_active:
             _LOGGER.debug("Außentemperatur-Abschaltung aktiv – Heizung gesperrt")
@@ -1081,6 +1089,7 @@ class SmartHeatingController:
             actual = self._room_temp(room)
             target = self._effective_target_for_room(room)
             pause_active = self._window_pause_active(room_id, room)
+            mode = self._get_room_heating_mode(room)
 
             predicted_overshoot = (
                 self._get_predicted_overshoot(room, tolerance)
@@ -1090,6 +1099,7 @@ class SmartHeatingController:
 
             state = self._update_room_state(
                 room_id=room_id,
+                room=room,
                 target=target,
                 actual=actual,
                 pause_active=pause_active,

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.2.8"
+  "version": "3.3.0"
 }

--- a/custom_components/smartdome_heat_control/www/app.js
+++ b/custom_components/smartdome_heat_control/www/app.js
@@ -118,6 +118,17 @@ const I18N = {
     footer_note:
       'The apply button sets for all rooms: <strong>Day start = global day start</strong> and <strong>Night start = global night start</strong>.',
 
+    section_temperatures: "Temperatures",
+    global_target_day: "Day target temperature (°C)",
+    global_target_night: "Night target temperature (°C)",
+    global_away_temperature: "Away temperature (°C)",
+    apply_temps: "Apply global temperatures to all rooms",
+    footer_note_temps: "The apply button overwrites the day target, night target, and away temperature for all rooms with the global values.",
+    status_apply_temps_ok: "Global temperatures applied to all rooms.",
+
+    room_heating_mode: "Heating mode",
+    room_mode_global: "Global",
+
     rooms_title: "Rooms",
     rooms_subtitle:
       "Scrollable on the right so the global settings remain visible.",
@@ -283,6 +294,17 @@ const I18N = {
     footer_note:
       'Der Übernehmen-Button setzt für alle Räume: <strong>Tag-Start = globale Tag-Startzeit</strong> und <strong>Nacht-Start = globale Nacht-Startzeit</strong>.',
 
+    section_temperatures: "Temperaturen",
+    global_target_day: "Zieltemperatur Tag (°C)",
+    global_target_night: "Zieltemperatur Nacht (°C)",
+    global_away_temperature: "Away-Temperatur (°C)",
+    apply_temps: "Globale Temperaturen in alle Räume übernehmen",
+    footer_note_temps: "Der Übernehmen-Button setzt für alle Räume die Zieltemperatur Tag, Nacht und Away auf die globalen Werte.",
+    status_apply_temps_ok: "Globale Temperaturen wurden in alle Räume übernommen.",
+
+    room_heating_mode: "Heizmodus",
+    room_mode_global: "Global",
+
     rooms_title: "Räume",
     rooms_subtitle:
       "Rechts scrollbar, damit die Haupteinstellungen sichtbar bleiben.",
@@ -402,6 +424,9 @@ const DEFAULTS = {
   outdoor_sensor: "",
   outdoor_temp_cutoff_enabled: false,
   outdoor_temp_cutoff: 15.0,
+  global_target_day: 21.0,
+  global_target_night: 18.0,
+  global_away_temperature: 17.0,
   rooms: {},
   circuits: {},
 };
@@ -416,6 +441,8 @@ const state = {
 };
 
 const entityPickerState = new Map();
+const roomCollapsedState = new Map();
+let dragSrcRoomId = null;
 
 let els = {};
 
@@ -427,6 +454,10 @@ function initEls() {
     reloadRoomsBtn: document.getElementById("reloadRoomsBtn"),
     addRoomBtn: document.getElementById("addRoomBtn"),
     applyTimesToRoomsBtn: document.getElementById("applyTimesToRoomsBtn"),
+    applyTempsToRoomsBtn: document.getElementById("applyTempsToRoomsBtn"),
+    globalTargetDay: document.getElementById("global_target_day"),
+    globalTargetNight: document.getElementById("global_target_night"),
+    globalAwayTemperature: document.getElementById("global_away_temperature"),
     enabled: document.getElementById("enabled"),
     mainControlType: document.getElementById("main_control_type"),
     mainThermostatField: document.getElementById("main_thermostat_field"),
@@ -707,6 +738,8 @@ function normalizeRoom(roomId, room) {
     learned_overshoot_short: normalizeNumber(room?.learned_overshoot_short, 0.2),
     learned_overshoot_medium: normalizeNumber(room?.learned_overshoot_medium, 0.4),
     learned_overshoot_long: normalizeNumber(room?.learned_overshoot_long, 0.7),
+    order: typeof room?.order === "number" ? room.order : 0,
+    room_heating_mode: typeof room?.room_heating_mode === "string" ? room.room_heating_mode : "",
   };
 }
 
@@ -766,6 +799,9 @@ function normalizeConfig(input) {
     DEFAULTS.vacation_temperature
   );
   cfg.away_enabled = cfg.away_enabled === true;
+  cfg.global_target_day = normalizeNumber(cfg.global_target_day, DEFAULTS.global_target_day);
+  cfg.global_target_night = normalizeNumber(cfg.global_target_night, DEFAULTS.global_target_night);
+  cfg.global_away_temperature = normalizeNumber(cfg.global_away_temperature, DEFAULTS.global_away_temperature);
 
   if (!cfg.rooms || typeof cfg.rooms !== "object") {
     cfg.rooms = {};
@@ -1573,6 +1609,16 @@ function renderGlobalSettings() {
     );
   }
 
+  if (els.globalTargetDay) {
+    els.globalTargetDay.value = String(normalizeNumber(cfg.global_target_day, DEFAULTS.global_target_day));
+  }
+  if (els.globalTargetNight) {
+    els.globalTargetNight.value = String(normalizeNumber(cfg.global_target_night, DEFAULTS.global_target_night));
+  }
+  if (els.globalAwayTemperature) {
+    els.globalAwayTemperature.value = String(normalizeNumber(cfg.global_away_temperature, DEFAULTS.global_away_temperature));
+  }
+
   createModePicker(cfg.heating_mode);
   renderCircuits();
   updateMainLiveStatus();
@@ -1615,53 +1661,67 @@ function createRoomCard(roomId, room) {
   const wrapper = document.createElement("div");
   wrapper.className = "room";
   wrapper.dataset.roomId = roomId;
+  wrapper.draggable = true;
 
+  const isCollapsed = roomCollapsedState.get(roomId) === true;
   const areaText = room.area_id ? `Area: ${room.area_id}` : t("room_manual");
   const roomMeta = roomTitleMeta(room, roomId);
   const isAdaptive = getModePickerValue() === "adaptive";
   const ovShort = normalizeNumber(room.learned_overshoot_short, 0.2);
   const ovMedium = normalizeNumber(room.learned_overshoot_medium, 0.4);
   const ovLong = normalizeNumber(room.learned_overshoot_long, 0.7);
+  const roomMode = room.room_heating_mode || "";
+  const modeOptions = [
+    { value: "", label: t("room_mode_global") },
+    { value: "comfort", label: t("mode_comfort") },
+    { value: "balanced", label: t("mode_balanced") },
+    { value: "energy", label: t("mode_energy") },
+    { value: "adaptive", label: t("mode_adaptive") },
+  ].map(o => `<option value="${o.value}"${roomMode === o.value ? " selected" : ""}>${escapeHtml(o.label)}</option>`).join("");
 
   wrapper.innerHTML = `
     <div class="room-top">
-      <div>
-        <div class="room-title-row" style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
-          <div class="room-title">${escapeHtml(room.label || roomId)}</div>
-          <div class="room-title-meta" style="display:flex; align-items:center; gap:8px; font-size:14px;">
-            ${roomMeta}
+      <div style="display:flex; align-items:flex-start; gap:10px; width:100%;">
+        <span class="room-drag-handle" title="Ziehen zum Verschieben" style="cursor:grab; font-size:18px; padding:4px 2px; color:var(--muted); user-select:none; flex-shrink:0;">≡</span>
+        <div style="flex:1; min-width:0;">
+          <div class="room-title-row" style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
+            <div class="room-title">${escapeHtml(room.label || roomId)}</div>
+            <div class="room-title-meta" style="display:flex; align-items:center; gap:8px; font-size:14px;">
+              ${roomMeta}
+            </div>
           </div>
+          <div class="room-subtitle">${escapeHtml(areaText)}</div>
+          ${isAdaptive ? `
+          <div class="room-adaptive room-adaptive-display">
+            <span class="adaptive-bucket">
+              <span style="color:var(--muted)">▲ &lt;15min</span>
+              <span class="adaptive-bucket-value">${ovShort.toFixed(2)} °C</span>
+            </span>
+            <span class="adaptive-bucket">
+              <span style="color:var(--muted)">▲ 15–45min</span>
+              <span class="adaptive-bucket-value">${ovMedium.toFixed(2)} °C</span>
+            </span>
+            <span class="adaptive-bucket">
+              <span style="color:var(--muted)">▲ &gt;45min</span>
+              <span class="adaptive-bucket-value">${ovLong.toFixed(2)} °C</span>
+            </span>
+          </div>` : ""}
         </div>
-        <div class="room-subtitle">${escapeHtml(areaText)}</div>
-        ${isAdaptive ? `
-        <div class="room-adaptive room-adaptive-display">
-          <span class="adaptive-bucket">
-            <span style="color:var(--muted)">▲ &lt;15min</span>
-            <span class="adaptive-bucket-value">${ovShort.toFixed(2)} °C</span>
+        <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap; flex-shrink:0;">
+          <span class="pill">
+            <input class="room-enabled" type="checkbox" ${
+              room.enabled ? "checked" : ""
+            } />
+            <span>${escapeHtml(t("room_active"))}</span>
           </span>
-          <span class="adaptive-bucket">
-            <span style="color:var(--muted)">▲ 15–45min</span>
-            <span class="adaptive-bucket-value">${ovMedium.toFixed(2)} °C</span>
-          </span>
-          <span class="adaptive-bucket">
-            <span style="color:var(--muted)">▲ &gt;45min</span>
-            <span class="adaptive-bucket-value">${ovLong.toFixed(2)} °C</span>
-          </span>
-        </div>` : ""}
+          <button class="ghost room-schedule-btn" type="button">${escapeHtml(t("room_schedule"))}</button>
+          <button class="danger room-delete-btn" type="button">${escapeHtml(t("room_delete"))}</button>
+          <button class="ghost room-collapse-btn" type="button" title="${isCollapsed ? "Aufklappen" : "Einklappen"}" style="padding:4px 10px; font-size:16px;">${isCollapsed ? "▶" : "▼"}</button>
+        </div>
       </div>
-      <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
-        <span class="pill">
-          <input class="room-enabled" type="checkbox" ${
-            room.enabled ? "checked" : ""
-          } />
-          <span>${escapeHtml(t("room_active"))}</span>
-        </span>
-        <button class="ghost room-schedule-btn" type="button">${escapeHtml(
-          t("room_schedule")
-        )}</button>
-        <button class="danger room-delete-btn" type="button">${escapeHtml(
-          t("room_delete")
-        )}</button>
+      <div class="room-mode-row" style="margin-top:8px; display:flex; align-items:center; gap:8px;">
+        <label style="font-size:13px; color:var(--muted); white-space:nowrap;">${escapeHtml(t("room_heating_mode"))}:</label>
+        <select class="room-heating-mode" style="font-size:13px; padding:3px 6px;">${modeOptions}</select>
       </div>
     </div>
 
@@ -1853,11 +1913,85 @@ function createRoomCard(roomId, room) {
 
   deleteBtn.addEventListener("click", () => {
     delete state.config.rooms[roomId];
+    roomCollapsedState.delete(roomId);
     renderRooms();
   });
 
   scheduleBtn.addEventListener("click", () => {
     openScheduleModal(roomId);
+  });
+
+  // Collapse / Expand
+  const collapseBtn = wrapper.querySelector(".room-collapse-btn");
+  const roomGrid = wrapper.querySelector(".room-grid");
+  const roomAdvanced = wrapper.querySelector(".room-advanced");
+  const roomModeRow = wrapper.querySelector(".room-mode-row");
+
+  function applyCollapsed(collapsed) {
+    if (roomGrid) roomGrid.style.display = collapsed ? "none" : "";
+    if (roomAdvanced) roomAdvanced.style.display = "none"; // advanced stays closed when collapsing
+    if (roomModeRow) roomModeRow.style.display = collapsed ? "none" : "";
+    if (collapseBtn) collapseBtn.textContent = collapsed ? "▶" : "▼";
+  }
+
+  applyCollapsed(isCollapsed);
+
+  collapseBtn.addEventListener("click", () => {
+    const nowCollapsed = roomCollapsedState.get(roomId) !== true;
+    roomCollapsedState.set(roomId, nowCollapsed);
+    applyCollapsed(nowCollapsed);
+  });
+
+  // Drag and Drop
+  wrapper.addEventListener("dragstart", (e) => {
+    dragSrcRoomId = roomId;
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", roomId);
+    wrapper.style.opacity = "0.5";
+  });
+
+  wrapper.addEventListener("dragend", () => {
+    wrapper.style.opacity = "";
+    els.roomsContainer.querySelectorAll(".room").forEach(n => n.classList.remove("drag-over"));
+  });
+
+  wrapper.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    els.roomsContainer.querySelectorAll(".room").forEach(n => n.classList.remove("drag-over"));
+    wrapper.classList.add("drag-over");
+  });
+
+  wrapper.addEventListener("dragleave", () => {
+    wrapper.classList.remove("drag-over");
+  });
+
+  wrapper.addEventListener("drop", (e) => {
+    e.preventDefault();
+    wrapper.classList.remove("drag-over");
+    if (!dragSrcRoomId || dragSrcRoomId === roomId) return;
+
+    const srcNode = els.roomsContainer.querySelector(`.room[data-room-id="${dragSrcRoomId}"]`);
+    if (!srcNode) return;
+
+    const allNodes = [...els.roomsContainer.querySelectorAll(".room")];
+    const srcIdx = allNodes.indexOf(srcNode);
+    const dstIdx = allNodes.indexOf(wrapper);
+
+    if (srcIdx < dstIdx) {
+      wrapper.after(srcNode);
+    } else {
+      wrapper.before(srcNode);
+    }
+
+    // Update order in state
+    const updatedNodes = [...els.roomsContainer.querySelectorAll(".room")];
+    updatedNodes.forEach((n, i) => {
+      const rid = n.dataset.roomId;
+      if (state.config.rooms[rid]) state.config.rooms[rid].order = i;
+    });
+
+    dragSrcRoomId = null;
   });
 
   return wrapper;
@@ -1875,6 +2009,9 @@ function renderRooms() {
     els.roomsContainer.appendChild(empty);
     return;
   }
+
+  // Sort by order field
+  entries.sort((a, b) => (a[1].order ?? 0) - (b[1].order ?? 0));
 
   const circuits = state.config.circuits || {};
   const hasCircuits = Object.keys(circuits).length > 0;
@@ -2036,10 +2173,21 @@ function collectFormState() {
     ? normalizeNumber(els.outdoorTempCutoff.value, DEFAULTS.outdoor_temp_cutoff)
     : DEFAULTS.outdoor_temp_cutoff;
 
+  cfg.global_target_day = els.globalTargetDay
+    ? normalizeNumber(els.globalTargetDay.value, DEFAULTS.global_target_day)
+    : DEFAULTS.global_target_day;
+  cfg.global_target_night = els.globalTargetNight
+    ? normalizeNumber(els.globalTargetNight.value, DEFAULTS.global_target_night)
+    : DEFAULTS.global_target_night;
+  cfg.global_away_temperature = els.globalAwayTemperature
+    ? normalizeNumber(els.globalAwayTemperature.value, DEFAULTS.global_away_temperature)
+    : DEFAULTS.global_away_temperature;
+
   const rooms = {};
   const roomNodes = els.roomsContainer.querySelectorAll(".room");
 
-  for (const node of roomNodes) {
+  for (let i = 0; i < roomNodes.length; i++) {
+    const node = roomNodes[i];
     const roomId = node.dataset.roomId;
     const existingRoom = state.config.rooms[roomId] || {};
 
@@ -2067,6 +2215,8 @@ function collectFormState() {
       night_setback_enabled: node.querySelector(".room-night-setback-enabled")?.checked !== false,
       learned_overshoot: existingRoom.learned_overshoot,
       circuit_id: node.querySelector(".room-circuit-id")?.value || existingRoom.circuit_id || "",
+      order: i,
+      room_heating_mode: node.querySelector(".room-heating-mode")?.value || "",
     });
   }
 
@@ -2102,6 +2252,7 @@ function generateRoomId() {
 
 function addRoom() {
   const roomId = generateRoomId();
+  const existingCount = Object.keys(state.config.rooms).length;
   state.config.rooms[roomId] = {
     label: t("room_new"),
     area_id: "",
@@ -2112,17 +2263,43 @@ function addRoom() {
     control_profile: "standard",
     thermostat_offset: 0.0,
     circuit_id: "",
-    target_day: 21.0,
-    target_night: 18.0,
-    away_temperature: 17.0,
+    target_day: normalizeNumber(els.globalTargetDay?.value, DEFAULTS.global_target_day),
+    target_night: normalizeNumber(els.globalTargetNight?.value, DEFAULTS.global_target_night),
+    away_temperature: normalizeNumber(els.globalAwayTemperature?.value, DEFAULTS.global_away_temperature),
     weekly_schedule: structuredClone(DEFAULT_WEEKLY_SCHEDULE),
     day_start: "",
     night_start: "",
     enabled: true,
     night_setback_enabled: true,
     learned_overshoot: 0.3,
+    order: existingCount,
+    room_heating_mode: "",
   };
   renderRooms();
+}
+
+function applyGlobalTempsToAllRooms() {
+  const globalDay = normalizeNumber(els.globalTargetDay?.value, DEFAULTS.global_target_day);
+  const globalNight = normalizeNumber(els.globalTargetNight?.value, DEFAULTS.global_target_night);
+  const globalAway = normalizeNumber(els.globalAwayTemperature?.value, DEFAULTS.global_away_temperature);
+
+  const roomNodes = els.roomsContainer.querySelectorAll(".room");
+  if (!roomNodes.length) {
+    setStatus(t("status_no_rooms_apply"), "warn");
+    return;
+  }
+
+  for (const node of roomNodes) {
+    const dayInput = node.querySelector(".room-target-day");
+    const nightInput = node.querySelector(".room-target-night");
+    const awayInput = node.querySelector(".room-away-temperature");
+    if (dayInput) dayInput.value = String(globalDay);
+    if (nightInput) nightInput.value = String(globalNight);
+    if (awayInput) awayInput.value = String(globalAway);
+  }
+
+  state.config = collectFormState();
+  setStatus(t("status_apply_temps_ok"), "ok");
 }
 
 function applyGlobalTimesToAllRooms() {
@@ -2501,6 +2678,9 @@ function bindEvents() {
     "click",
     applyGlobalTimesToAllRooms
   );
+  if (els.applyTempsToRoomsBtn) {
+    els.applyTempsToRoomsBtn.addEventListener("click", applyGlobalTempsToAllRooms);
+  }
   if (els.addCircuitBtn) {
     els.addCircuitBtn.addEventListener("click", addCircuit);
   }

--- a/custom_components/smartdome_heat_control/www/index.html
+++ b/custom_components/smartdome_heat_control/www/index.html
@@ -536,6 +536,11 @@
       background: #10161e;
     }
 
+    .room.drag-over {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px var(--accent);
+    }
+
     .room-top {
       display: flex;
       justify-content: space-between;
@@ -1197,6 +1202,34 @@
               Der Übernehmen-Button setzt für alle Räume:
               <strong>Tag-Start = globale Tag-Startzeit</strong> und
               <strong>Nacht-Start = globale Nacht-Startzeit</strong>.
+            </div>
+          </div>
+
+          <!-- Temperaturen -->
+          <div class="settings-group">
+            <div class="settings-group-label" data-i18n="section_temperatures">Temperaturen</div>
+            <div class="fields">
+              <div class="field">
+                <label for="global_target_day" data-i18n="global_target_day">Zieltemperatur Tag (°C)</label>
+                <input id="global_target_day" type="number" min="5" max="30" step="0.5" value="21" />
+              </div>
+              <div class="field">
+                <label for="global_target_night" data-i18n="global_target_night">Zieltemperatur Nacht (°C)</label>
+                <input id="global_target_night" type="number" min="5" max="30" step="0.5" value="18" />
+              </div>
+              <div class="field">
+                <label for="global_away_temperature" data-i18n="global_away_temperature">Away-Temperatur (°C)</label>
+                <input id="global_away_temperature" type="number" min="5" max="25" step="0.5" value="17" />
+              </div>
+            </div>
+            <div class="sub-actions">
+              <button id="applyTempsToRoomsBtn" class="ghost" data-i18n="apply_temps">
+                Globale Temperaturen in alle Räume übernehmen
+              </button>
+            </div>
+            <div class="footer-note" data-i18n="footer_note_temps">
+              Der Übernehmen-Button setzt für alle Räume die globalen Ziel- und Away-Temperaturen.
+              Raumspezifische Werte werden dabei überschrieben.
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

- **#54 Globale Temperatureinstellungen** — Neuer Abschnitt "Temperaturen" in der Sidebar mit globalen Tag/Nacht/Away-Werten + Button "Globale Temperaturen in alle Räume übernehmen". Neue Räume übernehmen automatisch die globalen Werte.
- **#53 Raum-Reihenfolge** — Räume per Drag & Drop (≡ Handle) neu anordnen; Reihenfolge wird persistiert. Jede Raumkarte ist per ▼/▶ Button ein-/ausklappbar.
- **#56 Heizmodus pro Raum** — Dropdown in jeder Raumkarte (Global / Comfort / Balanced / Energy / Adaptive). Controller nutzt den Raum-Override wenn gesetzt, sonst globalen Modus.

## Test plan

- [ ] Globale Temperaturen setzen → "Auf alle Räume anwenden" → alle Raumwerte aktualisiert
- [ ] Neuen Raum anlegen → übernimmt globale Temperaturwerte
- [ ] Räume per Drag & Drop verschieben → Reihenfolge nach Speichern erhalten
- [ ] Raumkarte ein-/ausklappen → State bleibt bei Re-Render erhalten
- [ ] Raum auf "Energy" setzen → dieser Raum nutzt Energy-Logik, andere weiter global
- [ ] Globalen Modus ändern → Räume mit "Global" folgen, Räume mit Override bleiben unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)