### PR TITLE
diag: Logging für Bug #57 (Konfiguration wird überschrieben) (V3.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [3.3.1] – 2026-04-02
+
+### 🔍 Diagnose: Logging für Bug #57 (Konfiguration wird überschrieben)
+
+Temporäre `WARNING`-Logs wurden an allen Stellen eingebaut, die den Config Entry schreiben oder den Controller aktualisieren:
+
+- `WS_SAVE` – WebSocket-Speichern aus dem Panel
+- `UPDATE_CONFIG` – Controller erhält neue Config
+- `PERSIST_LEARNED_VALUES` – Controller erstellt Persist-Task nach Lernzyklus
+- `PERSIST_LEARNED` – Config Entry wird tatsächlich geschrieben
+- `SERVICE_UPDATE_CONFIG` – HA-Service `update_config` aufgerufen
+- `UPDATE_LISTENER` – Config-Entry-Änderung löst Reload aus
+
+Die Logs erscheinen im HA-Log (`home-assistant.log`) mit dem Präfix `[Smartdome Diagnose]`.
+
+---
+
 ## [3.3.0] – 2026-04-02
 
 ### ✨ Feature: Globale Temperatureinstellungen (#54)

--- a/custom_components/smartdome_heat_control/__init__.py
+++ b/custom_components/smartdome_heat_control/__init__.py
@@ -127,6 +127,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = domain_data
 
     async def _persist_learned(config: dict[str, Any]) -> None:
+        rooms = config.get(CONF_ROOMS, {})
+        _LOGGER.warning(
+            "[Smartdome Diagnose] PERSIST_LEARNED: Schreibe Config Entry. "
+            "Räume: %s | heating_mode: %s | enabled: %s",
+            {rid: r.get("label", rid) for rid, r in rooms.items()},
+            config.get("heating_mode"),
+            config.get("enabled"),
+        )
         hass.config_entries.async_update_entry(entry, data=config)
         domain_data["config"] = config
 
@@ -201,6 +209,7 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload bei Änderungen im Options Flow."""
+    _LOGGER.warning("[Smartdome Diagnose] UPDATE_LISTENER: Config Entry wurde geändert → Reload wird ausgelöst.")
     await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -382,6 +391,15 @@ def _async_register_ws_save_config(hass: HomeAssistant) -> None:
 
         new_cfg = _normalize_config(dict(msg["config"]))
 
+        rooms = new_cfg.get(CONF_ROOMS, {})
+        _LOGGER.warning(
+            "[Smartdome Diagnose] WS_SAVE: Konfiguration wird gespeichert. "
+            "Räume: %s | heating_mode: %s | enabled: %s",
+            {rid: r.get("label", rid) for rid, r in rooms.items()},
+            new_cfg.get("heating_mode"),
+            new_cfg.get("enabled"),
+        )
+
         hass.config_entries.async_update_entry(target_entry, data=new_cfg)
         data["config"] = new_cfg
 
@@ -405,6 +423,8 @@ def _async_register_services(hass: HomeAssistant) -> None:
         if target_entry is None:
             _LOGGER.warning("Kein Config Entry für update_config gefunden")
             return
+
+        _LOGGER.warning("[Smartdome Diagnose] SERVICE_UPDATE_CONFIG aufgerufen. Patch-Keys: %s", list(call.data.get("config", {}).keys()))
 
         data = hass.data[DOMAIN][target_entry.entry_id]
         current_cfg = dict(data["config"])

--- a/custom_components/smartdome_heat_control/controller.py
+++ b/custom_components/smartdome_heat_control/controller.py
@@ -232,6 +232,14 @@ class SmartHeatingController:
 
     def update_config(self, config: dict[str, Any]) -> None:
         """Config aktualisieren."""
+        rooms = config.get("rooms", {})
+        _LOGGER.warning(
+            "[Smartdome Diagnose] UPDATE_CONFIG: Controller erhält neue Config. "
+            "Räume: %s | heating_mode: %s | enabled: %s",
+            {rid: r.get("label", rid) for rid, r in rooms.items()},
+            config.get("heating_mode"),
+            config.get("enabled"),
+        )
         self.config = config
         self._apply_config_defaults()
         self._reset_runtime_states()
@@ -318,6 +326,14 @@ class SmartHeatingController:
     def _persist_learned_values(self) -> None:
         """Gelernte Werte in den Config Entry schreiben."""
         if self._persist_callback is not None:
+            rooms = self.config.get("rooms", {})
+            _LOGGER.warning(
+                "[Smartdome Diagnose] PERSIST_LEARNED_VALUES: Erstelle Persist-Task. "
+                "Räume: %s | heating_mode: %s | enabled: %s",
+                {rid: r.get("label", rid) for rid, r in rooms.items()},
+                self.config.get("heating_mode"),
+                self.config.get("enabled"),
+            )
             self.hass.async_create_task(self._persist_callback(dict(self.config)))
 
     def _as_entity_id(self, value: Any) -> str | None:

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.3.0"
+  "version": "3.3.1"
 }


### PR DESCRIPTION
## Summary

- Temporäre `WARNING`-Logs an allen Stellen eingebaut, die den Config Entry schreiben
- Erkennbar im HA-Log am Präfix `[Smartdome Diagnose]`
- Hilft zu diagnostizieren welcher Code-Pfad Bug #57 verursacht

## Zu prüfende Log-Einträge

| Präfix | Bedeutung |
|--------|-----------|
| `WS_SAVE` | Benutzer speichert über Panel |
| `UPDATE_CONFIG` | Controller erhält neue Config |
| `PERSIST_LEARNED_VALUES` | Lernzyklus abgeschlossen → Task wird erstellt |
| `PERSIST_LEARNED` | Config Entry wird tatsächlich geschrieben |
| `SERVICE_UPDATE_CONFIG` | HA-Service `update_config` aufgerufen |
| `UPDATE_LISTENER` | Config-Entry-Änderung → Reload ausgelöst |

## Erwartetes Verhalten bei gesundem System
1. Speichern: `WS_SAVE` → `UPDATE_CONFIG` → `UPDATE_LISTENER` → (Reload)
2. Nach Heizzyklus: `PERSIST_LEARNED_VALUES` → `PERSIST_LEARNED` (mit aktuellen Werten)

## Verdacht
`PERSIST_LEARNED` könnte nach `WS_SAVE` noch mit alten Werten schreiben (Task aus vorherigem Evaluate-Cycle war bereits in Queue).

Closes #57 (nach Diagnose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)