### PR TITLE
fix: Race-Condition in _persist_learned behoben (V3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.3.2] – 2026-04-02
+
+### 🔧 Fix: Konfiguration wird nach Heizzyklus überschrieben (Bug #57)
+
+**Ursache (Race-Condition):** `_persist_learned_values()` erstellte einen Async-Task mit einer Kopie von `self.config` zum Zeitpunkt der Task-Erstellung. Wenn der Nutzer kurz danach gespeichert hat (`WS_SAVE` → `update_config()`), lief der bereits in der Queue befindliche Task mit dem alten Snapshot und überschrieb die neue Nutzer-Config im Config Entry.
+
+**Fix:** `_persist_learned` liest jetzt nicht mehr den übergebenen Snapshot, sondern immer den **aktuellen** `domain_data["config"]` aus. Es werden ausschließlich die gelernten Raumwerte (Overshoot-Buckets, Zyklus-State) per Feld-Merge aktualisiert — Nutzer-Einstellungen werden von diesem Pfad nie mehr angefasst.
+
+**Betroffene Felder (werden weiterhin persistiert):** `learned_overshoot` (short/medium/long/avg), `heating_cycle_active`, `cycle_target_temp`, `cycle_peak_temp`, `cycle_start_ts`, `cycle_peaked`, `calling_for_heat`.
+
+---
+
+**EN:** Fixed a race condition where `_persist_learned_values()` queued a task with a snapshot of `self.config`. If `update_config()` ran before the task executed, the stale snapshot overwrote the user's saved config. Fix: `_persist_learned` now reads from `domain_data["config"]` and only merges the learned fields, never touching user settings.
+
+---
+
 ## [3.3.1] – 2026-04-02
 
 ### 🔍 Diagnose: Logging für Bug #57 (Konfiguration wird überschrieben)

--- a/custom_components/smartdome_heat_control/__init__.py
+++ b/custom_components/smartdome_heat_control/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     DEFAULT_ROOM_THERMOSTAT_OFFSET,
     CONF_ROOM_AWAY_TEMPERATURE,
     CONF_ROOM_CALLING_FOR_HEAT,
+    CONF_ROOM_CYCLE_PEAKED,
     CONF_ROOM_NIGHT_SETBACK_ENABLED,
     CONF_ROOM_CYCLE_PEAK_TEMP,
     CONF_ROOM_CYCLE_START_TS,
@@ -126,17 +127,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
     hass.data[DOMAIN][entry.entry_id] = domain_data
 
-    async def _persist_learned(config: dict[str, Any]) -> None:
-        rooms = config.get(CONF_ROOMS, {})
+    # Nur diese Felder pro Raum werden durch den Lernprozess aktualisiert.
+    # Alle anderen Felder (Nutzer-Config) werden NICHT angefasst.
+    _LEARNED_ROOM_KEYS = (
+        CONF_ROOM_LEARNED_OVERSHOOT,
+        CONF_ROOM_LEARNED_OVERSHOOT_SHORT,
+        CONF_ROOM_LEARNED_OVERSHOOT_MEDIUM,
+        CONF_ROOM_LEARNED_OVERSHOOT_LONG,
+        CONF_ROOM_HEATING_CYCLE_ACTIVE,
+        CONF_ROOM_CYCLE_TARGET_TEMP,
+        CONF_ROOM_CYCLE_PEAK_TEMP,
+        CONF_ROOM_CYCLE_START_TS,
+        CONF_ROOM_CYCLE_PEAKED,
+        CONF_ROOM_CALLING_FOR_HEAT,
+    )
+
+    async def _persist_learned(learned: dict[str, Any]) -> None:
+        # Aktuellen Stand aus domain_data holen (nicht den übergebenen Snapshot verwenden).
+        # Das verhindert die Race-Condition, bei der ein veralteter Snapshot die
+        # kurz zuvor gespeicherte Nutzer-Config überschreibt.
+        current = dict(domain_data["config"])
+        current_rooms = current.get(CONF_ROOMS, {})
+        learned_rooms = learned.get(CONF_ROOMS, {})
+
+        changed = False
+        for room_id, learned_room in learned_rooms.items():
+            if room_id not in current_rooms:
+                continue
+            for key in _LEARNED_ROOM_KEYS:
+                new_val = learned_room.get(key)
+                if current_rooms[room_id].get(key) != new_val:
+                    current_rooms[room_id][key] = new_val
+                    changed = True
+
+        if not changed:
+            _LOGGER.debug("[Smartdome Diagnose] PERSIST_LEARNED: Keine Änderungen, Skip.")
+            return
+
         _LOGGER.warning(
-            "[Smartdome Diagnose] PERSIST_LEARNED: Schreibe Config Entry. "
-            "Räume: %s | heating_mode: %s | enabled: %s",
-            {rid: r.get("label", rid) for rid, r in rooms.items()},
-            config.get("heating_mode"),
-            config.get("enabled"),
+            "[Smartdome Diagnose] PERSIST_LEARNED: Merge lernbarer Werte in Config Entry. "
+            "Geänderte Räume: %s",
+            [rid for rid in learned_rooms if rid in current_rooms],
         )
-        hass.config_entries.async_update_entry(entry, data=config)
-        domain_data["config"] = config
+        hass.config_entries.async_update_entry(entry, data=current)
+        domain_data["config"] = current
 
     controller.set_persist_callback(_persist_learned)
 

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.3.1"
+  "version": "3.3.2"
 }


### PR DESCRIPTION
## Summary

Behebt Bug #57 (Konfiguration wird alle ~2 Minuten überschrieben).

## Root Cause

`_persist_learned_values()` im Controller erstellte einen Async-Task mit einer Snapshot-Kopie von `self.config` **zum Zeitpunkt der Task-Erstellung**:

```python
self.hass.async_create_task(self._persist_callback(dict(self.config)))  # BUGGY
```

Wenn der Nutzer nach einem Heizzyklus speichert:
1. Controller → `_persist_learned_values()` → Task mit ALTER Config in Queue
2. User → `WS_SAVE` → `update_config(neue Config)`
3. Task aus Queue läuft → schreibt ALTE Config in Config Entry → **User-Änderungen weg**

## Fix

`_persist_learned` liest jetzt `domain_data["config"]` (immer aktuell) statt den übergebenen Snapshot. Es werden **nur** die gelernten Felder per Merge aktualisiert — Nutzer-Einstellungen werden von diesem Pfad nie berührt.

## Test plan

- [ ] Config speichern, 2 Minuten warten → Werte bleiben erhalten
- [ ] Adaptive Lernwerte werden weiterhin nach Heizzyklus persistiert
- [ ] `[Smartdome Diagnose]`-Logs zeigen nur noch `PERSIST_LEARNED` mit korrekten Werten

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)