### PR TITLE
fix: app.js Cache-Busting (V3.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.3.3] – 2026-04-02
+
+### 🔧 Fix: app.js wurde vom Browser gecacht – neue Features nicht sichtbar
+
+`app.js` wurde mit einer hardcodierten Version `?v=3.2.6` geladen. Der Browser hat dadurch immer die alte Datei aus dem Cache verwendet, egal welche Version installiert war.
+
+**Fix:** Die Version wird jetzt dynamisch aus dem URL-Parameter von `index.html` ausgelesen (`?v=3.3.x`) und an den `app.js`-Load weitergegeben. Jede neue Version erzwingt automatisch einen Cache-Reload.
+
+---
+
 ## [3.3.2] – 2026-04-02
 
 ### 🔧 Fix: Konfiguration wird nach Heizzyklus überschrieben (Bug #57)

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.3.2"
+  "version": "3.3.3"
 }

--- a/custom_components/smartdome_heat_control/www/index.html
+++ b/custom_components/smartdome_heat_control/www/index.html
@@ -1547,6 +1547,14 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?v=3.2.6"></script>
+  <script>
+    (function() {
+      const v = new URLSearchParams(window.location.search).get('v') || 'dev';
+      const s = document.createElement('script');
+      s.type = 'module';
+      s.src = './app.js?v=' + v;
+      document.currentScript.replaceWith(s);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

`app.js` wurde mit hardcodiertem `?v=3.2.6` geladen — der Browser hat immer die alte Version aus dem Cache serviert. Alle neuen Features seit 3.3.0 (Drag & Drop, Collapse, Heizmodus pro Raum, etc.) waren dadurch unsichtbar.

**Fix:** Version wird dynamisch aus dem `?v=`-Parameter von `index.html` ausgelesen und an den `<script>`-Tag weitergegeben. Ab sofort erzwingt jedes neue Release automatisch einen Cache-Reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)