### PR TITLE
fix: Wochenschema verliert Temperatur-Eingaben beim Umsortieren (V3.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.3.6] – 2026-04-13
+
+### 🔧 Fix: Wochenschema verliert Temperatur-Eingaben beim Umsortieren (Issue #66)
+
+**Ursache:** Im Schedule-Editor wurde bei jeder Zeiteingabe (`change`-Event) `renderScheduleEditor()` aufgerufen, das alle DOM-Elemente zerstört und neu aufbaut. Wenn ein Nutzer eine Temperatur eingegeben, aber das Feld noch nicht verlassen hatte (kein `blur` → kein `change`-Event), wurde der Wert nicht in `draftWeeklySchedule` geschrieben und ging beim Re-Render verloren.
+
+**Fix:** Neue Funktion `flushScheduleEditorValues()` liest vor jedem Re-Render alle aktuellen DOM-Werte (Zeit + Temperatur) aus den bestehenden Zeilen in `draftWeeklySchedule` — auch wenn das `change`-Event noch nicht gefeuert hat. Die Funktion wird am Anfang von `renderScheduleEditor()` und `saveScheduleDraft()` aufgerufen.
+
+---
+
+**EN:** The schedule editor called `renderScheduleEditor()` on every time input change, destroying all DOM elements. If the user had typed a temperature but not blurred the field yet (no `change` event fired), the value was lost. Fix: new `flushScheduleEditorValues()` reads all current DOM values into `draftWeeklySchedule` before any re-render or save.
+
+**Fixes:** #66
+
+---
+
 ## [3.3.5] – 2026-04-09
 
 ### 🔧 Fix: Formularfelder werden durch Hintergrund-Events zurückgesetzt (Issue #65)

--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.3.5"
+  "version": "3.3.6"
 }

--- a/custom_components/smartdome_heat_control/www/app.js
+++ b/custom_components/smartdome_heat_control/www/app.js
@@ -2459,7 +2459,22 @@ function sortScheduleEntries(entries) {
   entries.sort((a, b) => a.start.localeCompare(b.start));
 }
 
+function flushScheduleEditorValues() {
+  if (!draftWeeklySchedule || !scheduleRoomId) return;
+  const entries = draftWeeklySchedule[currentScheduleDay];
+  if (!Array.isArray(entries)) return;
+  const rows = els.scheduleEntries.querySelectorAll(".schedule-entry");
+  rows.forEach((row, i) => {
+    if (!entries[i]) return;
+    const timeVal = row.querySelector(".schedule-time")?.value;
+    const tempVal = row.querySelector(".schedule-temp")?.value;
+    if (timeVal) entries[i].start = normalizeTime(timeVal, "06:00");
+    if (tempVal !== undefined && tempVal !== "") entries[i].temperature = normalizeNumber(tempVal, 21.0);
+  });
+}
+
 function renderScheduleEditor() {
+  flushScheduleEditorValues();
   renderScheduleDayButtons();
 
   if (!draftWeeklySchedule || !scheduleRoomId) {
@@ -2538,6 +2553,8 @@ function saveScheduleDraft() {
     closeScheduleModal();
     return;
   }
+
+  flushScheduleEditorValues();
 
   const room = state.config.rooms?.[scheduleRoomId];
   if (!room) {


### PR DESCRIPTION
## Summary

- Neue Funktion `flushScheduleEditorValues()` liest aktuelle DOM-Werte (Zeit + Temperatur) in `draftWeeklySchedule` bevor der Schedule-Editor neu gerendert wird
- Verhindert Datenverlust wenn Nutzer eine Temperatur eingegeben hat, das Feld aber noch nicht verlassen hatte (kein `change`-Event) und direkt danach eine Zeit änderte
- `flushScheduleEditorValues()` wird am Anfang von `renderScheduleEditor()` und `saveScheduleDraft()` aufgerufen

## Test plan

- [ ] Wochenschema für einen Raum öffnen
- [ ] Temperatur in einem Eintrag ändern (Feld NICHT verlassen / nicht klicken)
- [ ] Direkt danach die Uhrzeit eines anderen Eintrags ändern (löst Re-Render aus)
- [ ] Auf "Speichern" klicken
- [ ] Schema erneut öffnen → Temperatur muss erhalten sein

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)