### PR TITLE
fix: Erweitert-Panel öffnet sich nicht (Bug #73, V3.4.3)

### DIFF
--- a/custom_components/smartdome_heat_control/manifest.json
+++ b/custom_components/smartdome_heat_control/manifest.json
@@ -10,5 +10,5 @@
   "documentation": "https://github.com/19DMO89/smartdome_heat_control",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/19DMO89/smartdome_heat_control/issues",
-  "version": "3.4.2"
+  "version": "3.4.3"
 }

--- a/custom_components/smartdome_heat_control/www/app.js
+++ b/custom_components/smartdome_heat_control/www/app.js
@@ -2105,7 +2105,12 @@ function createRoomCard(roomId, room) {
 
   function applyCollapsed(collapsed) {
     if (roomGrid) roomGrid.style.display = collapsed ? "none" : "";
-    if (roomAdvanced) roomAdvanced.style.display = "none"; // advanced stays closed when collapsing
+    if (roomAdvanced) {
+      // Beim Einklappen: Inline-Style erzwingen + Klasse zurücksetzen
+      // Beim Aufklappen: Inline-Style leeren, damit .hidden-Klasse wieder greift
+      roomAdvanced.style.display = collapsed ? "none" : "";
+      if (collapsed) roomAdvanced.classList.add("hidden");
+    }
     if (roomModeRow) roomModeRow.style.display = collapsed ? "none" : "";
     if (collapseBtn) collapseBtn.textContent = collapsed ? "▶" : "▼";
   }


### PR DESCRIPTION
## Problem

Der **Erweitert**-Button in den Raumkarten ist sichtbar, aber beim Klicken passiert nichts — das Panel bleibt verborgen.

**Root Cause:** In `applyCollapsed()` wurde `roomAdvanced.style.display = "none"` **bedingungslos** gesetzt (auch beim Aufklappen des Raums). Dieser Inline-Style hat höhere Spezifität als CSS-Klassen und überschrieb daher den Toggle-Mechanismus des Erweitert-Buttons, der `.hidden` entfernt/hinzufügt.

**Sequenz:**
1. `applyCollapsed(false)` beim initialen Render → `roomAdvanced.style.display = "none"` ← Bug
2. User klickt Erweitert → `.hidden`-Klasse wird entfernt
3. CSS-Klasse steuert kein `display` mehr, aber Inline-Style bleibt → Panel bleibt unsichtbar

## Fix

`applyCollapsed()` setzt den Inline-Style nun **nur beim Einklappen** auf `"none"`. Beim Aufklappen wird er auf `""` geleert, damit `.hidden`-Klasse wieder die Sichtbarkeit übernimmt. Zusätzlich: `.hidden` wird beim Einklappen wieder gesetzt, damit der Erweitert-Button beim nächsten Aufklappen korrekt startet.

## Test plan

- [ ] Raumkarte aufgeklappt → Erweitert-Button klicken → Erweiterte Einstellungen erscheinen ✓
- [ ] Erweitert geöffnet → Raum einklappen → Erweitert ausgeblendet ✓
- [ ] Raum wieder aufklappen → Erweitert-Button startet wieder im geschlossenen Zustand ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)